### PR TITLE
update for Redmine 6

### DIFF
--- a/lib/redmine_slack/issue_patch.rb
+++ b/lib/redmine_slack/issue_patch.rb
@@ -5,7 +5,6 @@ module RedmineSlack
 			base.send(:include, InstanceMethods)
 
 			base.class_eval do
-				unloadable # Send unloadable so it will not be unloaded in development
 				after_create :create_from_issue
 				after_save :save_from_issue
 			end


### PR DESCRIPTION
fix error for unloadable causing since Redmine 6

```console
rake aborted!
NameError: undefined local variable or method `unloadable' for class Issue (NameError)
```